### PR TITLE
add 2 articles about Jekyll deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ _jekyll's Ferrari - obsessively designed toolkit for writing and deploying jekyl
     - Step 2: Setup certificate-based ssh access (server side)
     - Step 3: Rsync! (client-side)
     - Optional step 4: exclude transfer.sh from being copied to the output folder by Jekyll
+- [Deploy Jekyll sites to S3 using Travis CI](http://cloudcannon.com/tutorial/2016/01/21/deploy-jekyll-sites-to-s3-using-travis-ci/)
+- [Deploy Jekyll sites anywhere using jekyll-hook](http://cloudcannon.com/tutorial/2016/01/26/deploy-jekyll-sites-anywhere-with-jekyll-hook/)
 
 
 ## GitHub Pages Headquarters (HQ)


### PR DESCRIPTION
Added two useful articles from CloudCannon about Jekyll deployment.
One about deploying Jekyll site to Amazon S3 and other describes [jekyll-hook](https://github.com/developmentseed/jekyll-hook) setup.
