### PR TITLE
Add `jtasks` a CLI automation tool to simplify Jekyll routines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ See the **Awesome Markdown List @ Write Kit** (github: [writekit/awesome-markdow
 
 - [`jcli.sh`](http://www.skrauth.de/blog/2015/jekyll-bash-ui) (github: [StefanKrauth/shell-scripts/jcli.sh](https://github.com/StefanKrauth/shell-scripts/blob/master/jcli.sh)) - Jekyll Bash Command Line Interface by Stefan Krauth
 - ['jbh.sh']() (github: [alanbarber/jbh](https://github.com/alanbarber/jbh)) - Jekyll Blog Helper by Alan Barber
+- ['jtasks'](http://pavdmyt.com/simplifying-extending-jekyll-cli-with-jtasks/) (github: [pavdmyt/jtasks](https://github.com/pavdmyt/jtasks)) - simple, but powerful, interface to run both common and advanced routines in Jekyll projects by Pavel Dmytrenko
 
 ## "Visual" Editing Tools
 


### PR DESCRIPTION
[Jtasks](https://github.com/pavdmyt/jtasks) is a tool I created to simplify and automate a lot of dev routines in Jekyll projects. Currently it supports following tasks:

```
  build     Build the site.
  clean     Clean the site.
  doctor    Search site and print specific deprecation warnings.
  list      List all posts.
  notify    Notify various services about sitemap update.
  post      Create a new post.
  preview   Launches default browser for previewing generated site.
  serve     Serve the site locally.
```
