### PR TITLE
Readme: update jekyll cheatsheet URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ _The world's greatest static (web)sites_
 
 - **Jekyll Quick Reference (Cheat Sheet) @ Planet Jekyll** (github: [planetjekyll/quickrefs/JEKYLL.md](https://github.com/planetjekyll/quickrefs/blob/master/JEKYLL.md))
 - **Jekyll Cheat Sheet @ Jekyll Tips** (web: [cheat.jekyll.tips](http://cheat.jekyll.tips))
-
-<!-- not really updated/maintained
-- **Jekyll Cheat Sheet** (web: [ricostacruz.com/cheatsheets/jekyll.html](http://ricostacruz.com/cheatsheets/jekyll.html), github: [rstacruz/cheatsheets/jekyll.md](https://github.com/rstacruz/cheatsheets/blob/gh-pages/jekyll.md)) - by Rico Sta. Cruz
-  -->
+- **Jekyll Cheat Sheet @ Devhints.io** (web: [devhints.io/jekyll](https://devhints.io/jekyll), github: [rstacruz/cheatsheets/jekyll.md](https://github.com/rstacruz/cheatsheets/blob/gh-pages/jekyll.md)) - by Rico Sta. Cruz
 
 
 ## Books


### PR DESCRIPTION
http://ricostacruz.com/cheatsheets is now https://devhints.io :) (The old URL's are still accessible for now.)
