### PR TITLE
Add attranslate to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ See the **Awesome Markdown List @ Write Kit** (github: [writekit/awesome-markdow
 - [`jtasks`](http://pavdmyt.com/simplifying-extending-jekyll-cli-with-jtasks/) (github: [pavdmyt/jtasks](https://github.com/pavdmyt/jtasks)) by Pavel Dmytrenko - simple, but powerful, interface to run both common and advanced routines in Jekyll projects
 - [Jekyll Starter Kit](https://github.com/nirgn975/generator-jekyll-starter-kit) - A Jekyll Progressive Web App yeoman generator.
 - [Generator Jekyll Plugin](https://github.com/jamrizzi/generator-jekyll-plugin) by [Jam Risser](https://jam.jamrizzi.com) - 💎 Yeoman generator for jekyll plugins
+- [attranslate](https://github.com/fkirc/attranslate) by fkirc - A tool for synchronizing translation-files.
 
 
 ## "Visual" Editors n Tools


### PR DESCRIPTION
I felt that the Jekyll ecosystem still lacks free command-line tools for synchronizing translation-files, which is why I wrote [attranslate](https://github.com/fkirc/attranslate).
Of course, there exist tools like https://www.codeandweb.com/babeledit and many commercial platforms, but I did not see that many free command line tools that are simple to use.
